### PR TITLE
Update installation script to handle errors and exit with the appropriate status code

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -e -o pipefail
+
 #https://github.com/acmesh-official/get.acme.sh
 
 _exists() {
@@ -45,10 +47,13 @@ else
   exit 1
 fi
 
+$_get "$_url" | sh -s -- --install-online $_email "$@"
+_ret=$?
 
-if ! $_get "$_url" | sh -s -- --install-online $_email "$@"; then
+if [ $_ret -ne 0 ]; then
   echo "Install error"
   echo "中国大陆用户请参考:"
   echo "https://github.com/acmesh-official/acme.sh/wiki/Install-in-China"
 fi
 
+exit $_ret


### PR DESCRIPTION
@Neilpang @richard-vd After the change, the installer is able to exit with the curl's exit code.
```sh
$ sh index.html 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to raw.githubusercontent.com port 443 after 3 ms: Couldn't connect to server
$ echo $?
7
```